### PR TITLE
fix: add Prometheus configuration for metrics scraping

### DIFF
--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -1,0 +1,10 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: 'book-api'
+    static_configs:
+      - targets: ['localhost:3000']
+    metrics_path: '/metrics'
+    scrape_interval: 10s


### PR DESCRIPTION
- Configure scrape interval to 15s
- Add book-api job targeting port 3000
- Set metrics endpoint path
- Resolves empty prometheus.yml file

Closes #34